### PR TITLE
Add link to rss feed for auto discovery in feed readers

### DIFF
--- a/Sources/robb.swift/Components/Layouts.swift
+++ b/Sources/robb.swift/Components/Layouts.swift
@@ -49,6 +49,8 @@ extension Layout {
                     meta(content: "width=device-width, initial-scale=1.0", name: "viewport")
 
                     meta(content: "interest-cohort=()", httpEquiv: "Permissions-Policy")
+                    
+                    link(href: "/atom.xml", rel: "alternate", title: "RSS Feed for robb.is", type: "application/atom+xml")
 
                     (page as? Post).map { post -> Node in
                         return .fragment([


### PR DESCRIPTION
As advertised in the title. I added your blog to my RSS feed and could not auto detect it due to the missing link.